### PR TITLE
TensorBoard Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ venv.bak/
 
 # Model weights folder
 weights/
+
+# TensorBoard logs folder
+logs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torchtext==0.16.1
 torchinfo==1.8.0
 portalocker==2.8.2
 tabulate==0.9.0
+tensorboard==2.15.1


### PR DESCRIPTION
Integrate TensorBoard tracking into the training script. This automatically saves logs while training and allows real-time and post-training creation of graphs to compare performance between models.

At any time during or after training, graphs can be viewed by running the command `tensorboard --logdir=logs` and then navigating to the link provided by TensorBoard in a browser. An example of the TensorBoard results in the browser are below.

![image](https://github.com/DRAGNLabs/301r_retnet/assets/10404106/88c01b3b-43de-4cc7-b36a-78245432b337)
