### PR TITLE
Make mamba explicit param

### DIFF
--- a/slurm/generate.sh
+++ b/slurm/generate.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 python3 ../../generate.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/generate.sh
+++ b/slurm/generate.sh
@@ -15,4 +15,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
 mamba activate <your_env_name>
-python3 ../../generate.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+python3 ../../generate.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/generate.sh
+++ b/slurm/generate.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate <your_env_name>
 python3 ../../generate.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/inference.sh
+++ b/slurm/inference.sh
@@ -15,4 +15,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
 mamba activate <your_env_name>
-python3 ../../inference.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+python3 ../../inference.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/inference.sh
+++ b/slurm/inference.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate <your_env_name>
 python3 ../../inference.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/inference.sh
+++ b/slurm/inference.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 python3 ../../inference.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/run_eval.sh
+++ b/slurm/run_eval.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate change <your_env_name>
 python3 ../../run_eval.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/run_eval.sh
+++ b/slurm/run_eval.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 python3 ../../run_eval.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/run_eval.sh
+++ b/slurm/run_eval.sh
@@ -14,5 +14,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate change <your_env_name>
+mamba activate <your_env_name>
 python3 ../../run_eval.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/run_eval.sh
+++ b/slurm/run_eval.sh
@@ -15,4 +15,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
 mamba activate <your_env_name>
-python3 ../../run_eval.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+python3 ../../run_eval.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/tokenize_data.sh
+++ b/slurm/tokenize_data.sh
@@ -12,5 +12,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 python3 ../../tokenize_data.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/tokenize_data.sh
+++ b/slurm/tokenize_data.sh
@@ -12,5 +12,5 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate <your_env_name>
 python3 ../../tokenize_data.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/tokenize_data.sh
+++ b/slurm/tokenize_data.sh
@@ -13,4 +13,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
 mamba activate <your_env_name>
-python3 ../../tokenize_data.py ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+python3 ../../tokenize_data.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/train_model.sh
+++ b/slurm/train_model.sh
@@ -16,7 +16,7 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate <your_env_name>
 srun python3 \
     ../../train_model.py \
     ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/train_model.sh
+++ b/slurm/train_model.sh
@@ -16,7 +16,7 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 srun python3 \
     ../../train_model.py \
     ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/train_model.sh
+++ b/slurm/train_model.sh
@@ -19,4 +19,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 mamba activate <your_env_name>
 srun python3 \
     ../../train_model.py \
-    ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+    ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/train_tokenizer.sh
+++ b/slurm/train_tokenizer.sh
@@ -12,7 +12,7 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate <your_env_name>
+mamba activate <YOUR_ENV_NAME>
 python3 \
     ../../train_tokenizer.py \
     ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/slurm/train_tokenizer.sh
+++ b/slurm/train_tokenizer.sh
@@ -12,7 +12,7 @@
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 
 # LOAD MODULES, INSERT CODE, AND RUN YOUR PROGRAMS HERE
-mamba activate retnet
+mamba activate <your_env_name>
 python3 \
     ../../train_tokenizer.py \
     ../../configs/user_configs/YOUR_CONFIG_HERE.yaml

--- a/slurm/train_tokenizer.sh
+++ b/slurm/train_tokenizer.sh
@@ -15,4 +15,4 @@ export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
 mamba activate <your_env_name>
 python3 \
     ../../train_tokenizer.py \
-    ../../configs/user_configs/YOUR_CONFIG_HERE.yaml
+    ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml


### PR DESCRIPTION
This pull request just changed all the slurm templates mamba environments line from `mamba activate retnet` to `mamba activate <your_env_name>`. This is consistent with the new README.md instructions and lets users know they'll need to specify their own environmnet. 

Additionally, while making these changes, I noticed we had two place holding conventions. One involved using tags `<...>` and the other all caps `LIKE_SO`. I combined them to unify style, adding tags to the YAML place holder names and capitalizing the mamba text between `<>`, resulting in `<THIS_AS_THE_CONVENTION>`.