### PR TITLE
Generate 2 csv

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -27,6 +27,9 @@ input_starting_strings:
   - "A long time ago, in a galaxy far, far"
   - "It truly happened so suddenly! In one moment"
 
+# CSV Path (str): Path to CSV file to generate from; default None if not using
+csv_path: None
+
 # Model Path Directory (str): Path to model to run test harness on.
 # Example: "/tmp/data/models/<MODEL_NAME>/checkpoints/hf_ckpt_<CHECKPOINT_NUM>"
 model_path_dir: ~

--- a/generate.py
+++ b/generate.py
@@ -5,6 +5,7 @@ import yaml
 from models import RetNetModel, TransformerModel
 from transformers import PreTrainedTokenizerFast
 from utils import Struct, generate_text
+import datetime
 
 def generate_specific_text(config: Struct):
     """
@@ -44,6 +45,15 @@ def generate_specific_text(config: Struct):
     print("Generated strings:")
     for idx, string in enumerate(generated_strings):
         print(f"{idx+1}: {string}\n")
+
+    if config.csv_path is not None:
+        with open(config.csv_path, "w") as f:
+            for string in generated_strings:
+                # Get the current time
+                current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+                # Write the time and string to the file
+                f.write(f"{current_time}: {string}\n")
 
 
 if __name__ == "__main__":

--- a/generate.py
+++ b/generate.py
@@ -1,11 +1,12 @@
-import torch
+import csv
 import sys
+import torch
 import yaml
 
+from datetime import datetime
 from models import RetNetModel, TransformerModel
 from transformers import PreTrainedTokenizerFast
 from utils import Struct, generate_text
-import datetime
 
 def generate_specific_text(config: Struct):
     """
@@ -47,13 +48,11 @@ def generate_specific_text(config: Struct):
         print(f"{idx+1}: {string}\n")
 
     if config.csv_path is not None:
-        with open(config.csv_path, "w") as f:
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(config.csv_path, 'a', newline='') as outf:
+            writer = csv.writer(outf)
             for string in generated_strings:
-                # Get the current time
-                current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-                # Write the time and string to the file
-                f.write(f"{current_time}: {string}\n")
+                writer.writerow([current_time, config.model_type, string])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Our generate function simply prints output to a _.out_ file, but this is not ideal for using our outputs in downstream tasks. This PR adds functionality to write them out to a csv by specifiying a path in the yaml.
Thus: 
- a new parameter was set in the yaml (defaulting to none)
- a new function was added to the generate.py
- some imports were added

The function is only called if the yaml parameter is not none, and it will _appends_ to a file (intentionally not _writes_) the time of addition, the name of the model type that generated it, and the outputs themselves. There are no headers to these CSVs.
