### PR TITLE
add every n steps parameter

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -113,8 +113,10 @@ gamma: 0.85
 learning_rate: 0.001
 # Random Seed (int): Random seed for reproducibility
 rand_seed: 42
-# Save Top K (int): Number of best models to save
+# Save Top K (int): Number of best models to save. Set to -1 to save all
 save_top_k: 3
+# Every N Train Steps (int): Checkpoint every n train steps
+every_n_train_steps: 10000
 # Validation Check Interval (float): Validation frequency (fraction of an epoch)
 val_check_interval: 0.5
 

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -23,7 +23,7 @@ from utils import Struct
 torch.backends.cuda.matmul.allow_tf32 = True
 
 class CustomModelCheckpoint(ModelCheckpoint):
-    def __init__(self, dirpath, filename, monitor, save_top_k, mode,every_n_train_steps):
+    def __init__(self, dirpath, filename, monitor, save_top_k, mode, every_n_train_steps):
         super().__init__(
             dirpath=dirpath,
             filename=filename,

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -23,13 +23,14 @@ from utils import Struct
 torch.backends.cuda.matmul.allow_tf32 = True
 
 class CustomModelCheckpoint(ModelCheckpoint):
-    def __init__(self, dirpath, filename, monitor, save_top_k, mode):
+    def __init__(self, dirpath, filename, monitor, save_top_k, mode,every_n_train_steps):
         super().__init__(
             dirpath=dirpath,
             filename=filename,
             monitor=monitor,
             save_top_k=save_top_k,
-            mode=mode)
+            mode=mode,
+            every_n_train_steps=every_n_train_steps)
         self.num_ckpts = 0
 
     def on_save_checkpoint(self, trainer, pl_module, checkpoint):
@@ -135,7 +136,8 @@ def train_model(config: Struct):
         filename="epoch_{epoch}_validation_{val_loss:.2f}",
         monitor="val_loss",
         save_top_k=config.save_top_k,
-        mode="min")
+        mode="min",
+        every_n_train_steps=config.every_n_train_steps)
 
     early_stopping = EarlyStopping(
         "val_loss",


### PR DESCRIPTION
This PR adds a parameter `every_n_train_steps` that tells Lightning to save a checkpoint every n steps. The benefit of this is that we don't have to checkpoint just once an epoch, which can be very long for a large dataset.