### PR TITLE
Implement dynamic padding

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -145,13 +145,13 @@ class DataSet(torch.utils.data.IterableDataset):
 
         x_lengths = [len(line) for line in x]
         max_x_length = max(x_lengths)
-        padded_x = [line + [self.pad_token_id] * (max_x_length - len(line)) for line in x]
+        x_padded = [line + [self.pad_token_id] * (max_x_length - len(line)) for line in x]
 
-        y_true_lengths = [len(s) for s in y_true]
+        y_true_lengths = [len(line) for line in y_true]
         max_y_true_lengths = max(y_true_lengths)
-        padded_y_true = [line + [self.pad_token_id] * (max_y_true_lengths - len(line)) for line in y_true]
+        y_true_padded = [line + [self.pad_token_id] * (max_y_true_lengths - len(line)) for line in y_true]
 
-        padded_x = torch.tensor(padded_x)
-        padded_y_true = torch.tensor(padded_y_true)
+        x_padded = torch.tensor(x_padded)
+        y_true_padded = torch.tensor(y_true_padded)
 
-        return padded_x, padded_y_true
+        return x_padded, y_true_padded

--- a/src/tokenize_data.py
+++ b/src/tokenize_data.py
@@ -25,9 +25,8 @@ def tokenize_data(config, split):
         tokenization_dataframe = lambda series: \
             tokenizer(
                 series,
-                padding="max_length",
-                truncation=True,
-                max_length=config.seq_len + 1,
+                padding=False,
+                truncation=False,
                 return_token_type_ids=False,
                 return_attention_mask=False)["input_ids"]
 

--- a/src/tokenize_data.py
+++ b/src/tokenize_data.py
@@ -2,6 +2,7 @@ import argparse
 import dask
 dask.config.set({'dataframe.query-planning': True})
 import dask.dataframe as dd
+from dask.diagnostics import ProgressBar
 import pyarrow as pa
 import yaml
 
@@ -9,6 +10,7 @@ from pathlib import Path
 from transformers import PreTrainedTokenizerFast
 from utils import Struct
 
+ProgressBar().register()
 
 def tokenize_data(config, split):
 


### PR DESCRIPTION
This PR reworks the tokenization process, so that, instead of pre padding/truncating all tokenized sequences, it dynamically pads throughout training. This introduces flexibility for sequence length.

- Removes padding/truncation parameters from HF tokenization function
- Updates dataset iterator to work based on sequence length
- Adds padding function for data collation, for dynamic padding of sequence to sequence length.