### PR TITLE
Allow non-Slurm data tokenization in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The expected order of script execution is as follows:
 1. Change current directory to `scripts/user_scripts`.
 2. Run `download_data.sh` to fetch the necessary data.
 3. Execute `train_tokenizer.sh` to prepare the tokenizer.
-4. Use `tokenize_data.sh` for data tokenization.
+4. Use `tokenize_data.sh` for data tokenization and include the names of the data splits separated by spaces.
 5. Finally, run `train_model.sh`.
 
 For example, if you want to train a RetNet model:
@@ -64,7 +64,7 @@ cd scripts/user_scripts
 
 ./download_data.sh
 ./train_tokenizer.sh
-./tokenize_data.sh
+./tokenize_data.sh train validation test
 ./train_model.sh
 ```
 

--- a/scripts/tokenize_data.sh
+++ b/scripts/tokenize_data.sh
@@ -1,4 +1,36 @@
-python3 \
-    ../../src/tokenize_data.py \
-    ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml \
-    <YOUR_SPLIT_HERE> # train, validation, or test. You can start a job for each split.
+# Execute script with the names of the splits to tokenize, separated by spaces
+# Split names: train, validation, test
+
+# Define a function to run the Python command with a given argument
+run_command() {
+    local arg="$1"
+    python3 \
+        ../../src/tokenize_data.py \
+        ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml \
+        "$arg" &
+    pid=$!
+    echo "Started process with PID $pid for argument: $arg"
+    pids+=("$pid")
+}
+
+# Initialize an array to store process IDs
+pids=()
+
+# Check if arguments are provided
+if [ $# -eq 0 ]; then
+    echo "Error: No arguments provided."
+    exit 1
+fi
+
+# Run the Python command for each argument in parallel
+for arg in "$@"; do
+    run_command "$arg"
+done
+
+# Wait for all processes to finish
+for pid in "${pids[@]}"; do
+    wait "$pid"
+    echo "Process with PID $pid has finished."
+done
+
+echo "All processes have finished."


### PR DESCRIPTION
Allow the `tokenize_data.sh` script to perform multiple data split tokenizations at once, specified by the data split names passed in as arguments for the script.