### PR TITLE
Add perplexity metric

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -148,7 +148,5 @@ layers: 2
 model_type: "retnet" # Choices: "retnet", "transformer"
 # Sequence Length (int): Context window size by number of tokens
 seq_len: 128
-# Value Embedding Dimension (int): Value embed dimension size
-value_embed_dim: 12
 # Vocabulary Size (int): Maximum vocabulary size (unique tokens in vocabulary)
 vocab_size: 50000

--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -117,6 +117,8 @@ gamma: 0.85
 learning_rate: 0.001
 # Random Seed (int): Random seed for reproducibility
 rand_seed: 42
+# Precision (str): Precision for training; refer to Torch Lightning docs
+precision: fp16
 # Save Top K (int): Number of best models to save; default saves the best single checkpoint. Set to -1 to save all
 save_top_k: 3
 # Every N Train Steps (int): Checkpoint every n train steps; Note: PyTorch Lightning defines 'steps' as 

--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -148,5 +148,7 @@ layers: 2
 model_type: "retnet" # Choices: "retnet", "transformer"
 # Sequence Length (int): Context window size by number of tokens
 seq_len: 128
+# Value Embedding Dimension (int): Value embed dimension size
+value_embed_dim: 1280
 # Vocabulary Size (int): Maximum vocabulary size (unique tokens in vocabulary)
 vocab_size: 50000

--- a/src/models.py
+++ b/src/models.py
@@ -97,12 +97,24 @@ class RetNetModel(LightningModule):
         # Calculate loss
         loss = self.loss_fn(preds, targets)
 
+        perplexity = torch.exp(loss)
+
         self.log(
             name="val_loss",
             value=loss,
             prog_bar=True,
             logger=True,
             on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            add_dataloader_idx=True)
+        
+        self.log(
+            name="val_perplexity", 
+            value=perplexity, 
+            prog_bar=True,
+            logger=True, 
+            on_step=False, 
             on_epoch=True,
             sync_dist=True,
             add_dataloader_idx=True)
@@ -236,12 +248,24 @@ class TransformerModel(LightningModule):
         # Calculate loss
         loss = self.loss_fn(preds, targets)
 
+        perplexity = torch.exp(loss)
+
         self.log(
             name="val_loss",
             value=loss,
             prog_bar=True,
             logger=True,
             on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            add_dataloader_idx=True)
+        
+        self.log(
+            name="val_perplexity", 
+            value=perplexity, 
+            prog_bar=True,
+            logger=True, 
+            on_step=False, 
             on_epoch=True,
             sync_dist=True,
             add_dataloader_idx=True)

--- a/src/models.py
+++ b/src/models.py
@@ -183,7 +183,6 @@ class TransformerModel(LightningModule):
         # Create Transformer Decoder configuration for HuggingFace model
         config = DecoderConfig(
             decoder_embed_dim=config.embed_dim,
-            decoder_value_embed_dim=config.value_embed_dim,
             decoder_attention_heads=config.heads,
             decoder_ffn_embed_dim=config.ffn_dim,
             decoder_layers=config.layers,

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -48,11 +48,6 @@ def train_model(config: Struct):
         f"{config.embed_dim / config.heads} -- not an even, whole number)! " + \
         "Try changing the Embedding Dimension or number of heads."
 
-    # Test that the value embedding dimension is divisible by number of heads
-    assert config.value_embed_dim % config.heads == 0, \
-        "Value Embed Dimension not divisible by number of heads " + \
-        f"({config.value_embed_dim} % {config.heads} != 0)!"
-
     # Set random seeds for torch, numpy, random, etc. with transformers library
     if config.rand_seed is not None:
         set_seed(config.rand_seed)

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -47,6 +47,11 @@ def train_model(config: Struct):
         f"({config.embed_dim} / {config.heads} = " + \
         f"{config.embed_dim / config.heads} -- not an even, whole number)! " + \
         "Try changing the Embedding Dimension or number of heads."
+    
+    # Test that the value embedding dimension is divisible by number of heads
+    assert config.value_embed_dim % config.heads == 0, \
+        "Value Embed Dimension not divisible by number of heads " + \
+        f"({config.value_embed_dim} % {config.heads} != 0)!"
 
     # Set random seeds for torch, numpy, random, etc. with transformers library
     if config.rand_seed is not None:

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -19,10 +19,6 @@ from transformers import set_seed
 from torchinfo import summary as model_summary
 from utils import Struct
 
-# Allow torch to run float32 matrix multiplications in lower precision for
-# better performance while training if hardware is capable
-torch.backends.cuda.matmul.allow_tf32 = True
-
 class CustomModelCheckpoint(ModelCheckpoint):
     def __init__(self, dirpath, filename, monitor, save_top_k, mode, every_n_train_steps):
         super().__init__(
@@ -157,7 +153,8 @@ def train_model(config: Struct):
             accumulate_grad_batches=config.accumulate_grad_batches,
             sync_batchnorm=True,
             callbacks=[early_stopping, model_checkpoint],
-            logger=tb_logger)
+            logger=tb_logger,
+            precision=config.precision)
     else:
         trainer = Trainer(
             default_root_dir=model_dir, # main directory for run
@@ -171,7 +168,8 @@ def train_model(config: Struct):
             sync_batchnorm=True,
             plugins=[SLURMEnvironment(requeue_signal=signal.SIGHUP)],
             callbacks=[early_stopping, model_checkpoint],
-            logger=tb_logger)
+            logger=tb_logger,
+            precision=config.precision)
         
     ## Set up carbon emissions tracker
 


### PR DESCRIPTION
- Remove the parameter 'value_embed_dim', and related assertion; it isn't being used anywhere in the code, seems vestigial from past refactoring.
- Add perplexity logging in validation step of model training.
- Add a parameter to the config file for precision, as well as passes that parameter to lightning during training, to use lower bit precision.