### PR TITLE
Fix iterator bug

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -109,9 +109,9 @@ class DataSet(torch.utils.data.IterableDataset):
         process_rank = get_rank()
 
         # Create iterator over rows
-        self.data = self.data.iterrows()
+        iterator = self.data.iterrows()
 
-        for index, item in enumerate(self.data):
+        for index, item in enumerate(iterator):
             if index % (num_workers * world_size) == (process_rank * num_workers + worker_id):
                 item = item[1].values[0].copy()
                 x = item[:self.seq_len]


### PR DESCRIPTION
This fixes a bug where: when creating an iterator across the rows of the data, for any dataloader, the code would reassign the object data variable to the generator, which would throw an error when the __iter__ function was called again. Instead, we assign the generator to a local variable.