### PR TITLE
Add nvidia-smi to save ckpt loop

### DIFF
--- a/src/train_model.py
+++ b/src/train_model.py
@@ -39,6 +39,9 @@ class CustomModelCheckpoint(ModelCheckpoint):
             os.path.join(self.dirpath, f"hf_ckpt_{self.num_ckpts}"))
         self.num_ckpts += 1
 
+        # Print GPU memory usage
+        print(run("nvidia-smi -q -d MEMORY", shell=True, capture_output=True).stdout)
+
 
 def train_model(config: Struct):
     # Test that the head dimension will be an even, whole number


### PR DESCRIPTION
This just adds printing of nvidia-smi to see GPU usage everytime we save a checkpoint. 