### PR TITLE
Replace fp16 with valid precision option

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -117,7 +117,7 @@ learning_rate: 0.001
 # Random Seed (int): Random seed for reproducibility
 rand_seed: 42
 # Precision (str): Precision for training; refer to Torch Lightning docs
-precision: fp16
+precision: bf16
 # Save Top K (int): Number of best models to save; default saves the best single checkpoint. Set to -1 to save all
 save_top_k: 3
 # Every N Train Steps (int): Checkpoint every n train steps; Note: PyTorch Lightning defines 'steps' as 


### PR DESCRIPTION
Before my single commit, training with the default issued the following error:

```
ValueError: Precision 'fp16' is invalid. Allowed precision values: ('transformer-engine', 'transformer-engine-float16', '16-true', '16-mixed', 'bf16-true', 'bf16-mixed', '32-true', '64-true', 64, 32, 16, '64', '32', '16', 'bf16')
```
My commit changed the default to bf16, which I can confirm works. For more info on why this is the best option for default, look at the PyTorch Lightning docs for [Mixed Precision Training](https://lightning.ai/docs/pytorch/1.5.9/advanced/mixed_precision.html) (or ask Jay or me).