### PR TITLE
Memory tracking

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -104,9 +104,10 @@ use_slurm: true
 
 # --------------------------- TRAINING CONFIGURATION ---------------------------
 
-# Accumulate Gradient Batches (int): Accumulate gradients over n batches; note how this interacts with every_n_train_steps
+# Accumulate Gradient Batches (int): Accumulate gradients over n batches; note how this interacts w/ every_n_train_steps
 accumulate_grad_batches: 1
-# Early Stopping (int): Number of epochs to wait before stopping training
+# Early Stopping (int): Number of validations w/out improvement to wait before stopping training;
+# 0 deactivates feature; Defaults to 3
 early_stopping: 3
 # Epochs (int): Number of epochs to train for
 epochs: 1

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -1,2 +1,2 @@
-export CODECARBON_LOG_LEVEL="error"
+export CODECARBON_LOG_LEVEL="error"   # Options: DEBUG, info (default), warning, error, critical
 python3 ../../src/train_model.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -1,1 +1,2 @@
+export CODECARBON_LOG_LEVEL="error"
 python3 ../../src/train_model.py ../../configs/user_configs/<YOUR_CONFIG_HERE>.yaml

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -41,8 +41,7 @@ class CustomModelCheckpoint(ModelCheckpoint):
         self.num_ckpts += 1
 
         # Print GPU memory usage
-        print(run("nvidia-smi -q -d MEMORY", shell=True, capture_output=True).stdout)
-
+        print(torch.cuda.memory_summary())  # Prints per device
 
 def train_model(config: Struct):
     # Test that the head dimension will be an even, whole number


### PR DESCRIPTION
This PR does a couple quick bug fixes, but the most important one is adding a GPU memory logger that actually works to `train_model.py`. Previously we basically tried printing `subprocess.run("nvidia-smi)` to the outfile, and while this works on single device slurm jobs, we get no output with our 8-gpu jobs, rendering it useless. I looked into it for a while, and decided we should use pytorch's tool, which I confirmed works with our use case. The only arguable disadvantage I see is that it reports per device, not all together like nvidia-smi might yield. There's no built-in way to unify these reports, unfortunately.

Other bug fixes:
- Quieting CodeCarbon logs in .sh files
- Adjusting some yaml info for early_stopping hyperparam  