### PR TITLE
Correct lm_eval dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dask==2024.2.1
 dask-expr==0.5.2
 dask-ml==2023.3.24
 fairscale==0.4.13
+lm_eval==0.4.2
 numpy==1.26.2
 portalocker==2.8.2
 pytorch-lightning==2.1.3
@@ -16,4 +17,3 @@ torch==2.1.1
 torchinfo==1.8.0
 torchtext==0.16.1
 transformers==4.36.2
-git+https://github.com/DRAGNLabs/lm-evaluation-harness.git


### PR DESCRIPTION
We need to use lm_eval's repo, not our fork of it. The fork has been deleted.