### PR TITLE
Fix file_name formatting in CustomModelCheckpoint constructor

### DIFF
--- a/src/train_model.py
+++ b/src/train_model.py
@@ -23,7 +23,7 @@ from utils import Struct
 class CustomModelCheckpoint(ModelCheckpoint):
     def __init__(self, dirpath, monitor, save_top_k, mode, every_n_train_steps):
         self.num_ckpts = 0
-        self.file_name = f"{self.num_ckpts}_epoch_{epoch}_validation_{val_loss:.2f}"
+        self.file_name = f"{self.num_ckpts}"+"_epoch_{epoch}_validation_{val_loss:.2f}"
         
         super().__init__(
             dirpath=dirpath,


### PR DESCRIPTION
@nprisbrey , this is a fix for the problem you were experiencing

This fixes the file name. Epoch and val_loss are auto filled by torch lightning, as part of the super ModelCheckpoint class, so they should not be part of the formatted string.

I have verified that this works