### PR TITLE
Clarify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ Once your environment has been prepared, install all required packages:
 pip install -r requirements.txt
 ```
 
-To install Flash Attention:
-```bash
-pip install flash-attn==2.5.6 --no-build-isolation
-```
-
 ### 2: YAML Configuration Files
 
 This project uses YAML configuration files to store all pipeline parameters and paths. The design choice of the YAML file is intended to eliminate repetition of commonly used parameters across code, as well as simplify future changes and refactors, allow developers to add new parameters, and make all settings visible to the user in one consolidated place.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dask-expr==0.5.2
 dask-ml==2023.3.24
 einops==0.7.0
 fairscale==0.4.13
+flash-attn==2.5.6
 lm_eval==0.4.2
 numpy==1.26.2
 packaging==23.2


### PR DESCRIPTION
The extra flag on this import statement doesn't seem to be necessary given a virtual environment (or even without it?). See this [SO post](https://stackoverflow.com/questions/62889093/what-does-no-build-isolation-do#:~:text=When%20making%20build,replacing%20that%20version).

To limit confusion (which I spent 45 minutes with lol), I removed the flag and moved the import to `requirements.txt` with its corresponding version.

If the flag is still deemed important, it seems one can keep it in the requirements.txt according to this [SO post](https://stackoverflow.com/questions/76831476/how-do-i-specify-compiler-flags-in-a-requirements-txt-for-pip). This is no longer a [supported flag](https://pip.pypa.io/en/latest/reference/requirements-file-format/#supported-options) for pip's requirements.txt, so options then include rolling pip back (pip-20.2.2 works) finding another flag that is supported that does a similar thing, or cutting the flag and use an environement.