### PR TITLE
lr_find

### DIFF
--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -150,6 +150,7 @@ gamma: 0.85
 # Gradient Clip Val (float): Value for gradient clipping
 gradient_clip_val: 2.0
 # Learning Rate (float or str): Learning rate of model to train; put 'find' to use the learning rate finder feature (experimental).
+# Note: finder is naturally incompatible with grid search, assert error will be raised.
 learning_rate: 0.001
 # Random Seed (int): Random seed for reproducibility
 rand_seed: 42

--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -149,7 +149,7 @@ every_n_train_steps: 10000
 gamma: 0.85
 # Gradient Clip Val (float): Value for gradient clipping
 gradient_clip_val: 2.0
-# Learning Rate (float): Learning rate of model to train
+# Learning Rate (float or str): Learning rate of model to train; put 'find' to use the learning rate finder feature (experimental).
 learning_rate: 0.001
 # Random Seed (int): Random seed for reproducibility
 rand_seed: 42

--- a/configs/template_config.yaml
+++ b/configs/template_config.yaml
@@ -105,7 +105,7 @@ tokenizer_path: <YOUR_PATH_HERE>/data/tokenizers/c4_tokenizer
 # Tokenize Data (str): Path to tokenized dataset folder
 tokenized_dataset_path: <YOUR_PATH_HERE>/data/tokenized_dataset/c4
 
-# Emissions Outfile (Optional) (string): Name of .csv file to write tracked emissions to.
+# Emissions Outfile (Optional) (str): Name of .csv file to write tracked emissions to.
 # If left empty, defaults to 'emissions.csv'; writes to <models_path+model_name>/<CO2_outfile>
 CO2_outfile: ~ # Example: CO2_grid_search.csv
 
@@ -122,7 +122,7 @@ num_proc: 4
 # Num Workers (int): Number of workers for dataloaders. Recommended to set to
 # one less than number of CPU cores available
 num_workers: 0
-# Strategy (string): Distributed strategy for training. Likely no need to change
+# Strategy (str): Distributed strategy for training. Likely no need to change
 strategy: ddp # Options: 'ddp', 'ddp_spawn'
 # Use Slurm (bool): Whether to use Slurm for training
 use_slurm: true

--- a/src/grid_search.py
+++ b/src/grid_search.py
@@ -32,7 +32,7 @@ def grid_search(config: Struct):
         config (Struct): A Struct object with all configuration fields.
     """
         
-        assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
+    assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
 should not be a string (you put {config.learning_rate}).\nNote: You cannot use 'find' \
 feature in conjunction with grid search."
 

--- a/src/grid_search.py
+++ b/src/grid_search.py
@@ -196,5 +196,5 @@ if __name__ == "__main__":
         config = yaml.safe_load(f)
 
     config = Struct(**config)
-        
+
     grid_search(config)

--- a/src/grid_search.py
+++ b/src/grid_search.py
@@ -31,7 +31,7 @@ def grid_search(config: Struct):
     Args:
         config (Struct): A Struct object with all configuration fields.
     """
-        
+
     assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
 should not be a string (you put {config.learning_rate}).\nNote: You cannot use 'find' \
 feature in conjunction with grid search."

--- a/src/grid_search.py
+++ b/src/grid_search.py
@@ -31,9 +31,11 @@ def grid_search(config: Struct):
     Args:
         config (Struct): A Struct object with all configuration fields.
     """
-            assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
+        
+        assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
 should not be a string (you put {config.learning_rate}).\nNote: You cannot use 'find' \
 feature in conjunction with grid search."
+
     # Hyperparameters ranges to test
     learning_rates = [0.01, 0.001, 0.0001]
     embed_dims = [768, 1024, 1280]

--- a/src/grid_search.py
+++ b/src/grid_search.py
@@ -31,6 +31,9 @@ def grid_search(config: Struct):
     Args:
         config (Struct): A Struct object with all configuration fields.
     """
+            assert not isinstance(config.learning_rate, str), f"Error: 'config.learning_rate' \
+should not be a string (you put {config.learning_rate}).\nNote: You cannot use 'find' \
+feature in conjunction with grid search."
     # Hyperparameters ranges to test
     learning_rates = [0.01, 0.001, 0.0001]
     embed_dims = [768, 1024, 1280]
@@ -191,5 +194,5 @@ if __name__ == "__main__":
         config = yaml.safe_load(f)
 
     config = Struct(**config)
-
+        
     grid_search(config)

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -207,13 +207,19 @@ def train_model(config: Struct):
                 cloud_region="us-west3")
 
     
-    if config.learning_rate.lower() == "find":  # Use lr_find() from PyTorch Lightning; defaults to testing 100 samples.
-        tuner = Tuner(trainer)
-        lr_finder = tuner.lr_find(model, datamodule=dm)
-        print(lr_finder.results)
+    try:
+        config.learning_rate = config.learning_rate.lower()
+        if config.learning_rate == "find":
+            tuner = Tuner(trainer)
+            lr_finder = tuner.lr_find(model, datamodule=dm)
+            print(lr_finder.results)
 
-        fig = lr_finder.plot(suggest=True)
-        fig.savefig('lr_plot_transformer.png')
+            fig = lr_finder.plot(suggest=True)
+            fig.savefig('lr_plot_transformer.png')
+        else:
+            raise Exception("Invalid learning rate value.")
+    except AttributeError:
+        pass
 
             
     emissions_tracker.start()

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -206,6 +206,16 @@ def train_model(config: Struct):
                 cloud_provider="gcp",  # As of March 13, 2024, GCP us-west is the region with the most similar consumption profile to BYU.
                 cloud_region="us-west3")
 
+    
+    if config.learning_rate.lower() == "find":  # Use lr_find() from PyTorch Lightning; defaults to testing 100 samples.
+        tuner = Tuner(trainer)
+        lr_finder = tuner.lr_find(model, datamodule=dm)
+        print(lr_finder.results)
+
+        fig = lr_finder.plot(suggest=True)
+        fig.savefig('lr_plot_transformer.png')
+
+            
     emissions_tracker.start()
     trainer.fit(model, datamodule=dm)
 


### PR DESCRIPTION
### What's the deal?
This PR implements PyTorch's [lr_find()](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.tuner.tuning.Tuner.html#lightning.pytorch.tuner.tuning.Tuner.lr_find) feature in our code, basically a nifty grid search function just designed for the lr. 
### What should I expect to see?
The PR has the imlementation in train_model.py and also includes an assert statement to block it from happening in tandem with grid search (which doesn't make sense) and a way to invoke it detailed in the new template config.
I also standardized some of the type hinting in the template yaml changing the mix of `(str)` and `(string)` all to the former.
### Appendix
***Q:*** How many fords or fjords could a Ford ford if a Ford could ford fords and fjords?
***A:*** As many fords and fjords as a Ford could ford if a Ford could ford fords and fjords!