### PR TITLE
Edit typo

### DIFF
--- a/src/train_model.py
+++ b/src/train_model.py
@@ -20,8 +20,8 @@ from utils import Struct
 
 class CustomModelCheckpoint(ModelCheckpoint):
     def __init__(self, dirpath, monitor, save_top_k, mode, every_n_hours, every_n_train_steps):
-        self.num_ckpts = 000
-        self.file_name = f"{self.num_ckpts}" + "_{epoch}_{val_loss:.2f}"  # TorchLightning knows how to write out to non-f-string
+        self.num_ckpts = 0
+        self.file_name = "ckpt_" + f"{self.num_ckpts}".zfill(3) + "_{epoch}_{val_loss:.2f}"  # TorchLightning knows how to write out to non-f-string
         
         if every_n_hours is not None and every_n_train_steps is not None:
             if every_n_hours <= 0:


### PR DESCRIPTION
Issue #50 has a valid comment toward the bottom that if we don't set this name at the beginning, it won't match the folling checkpoints.