### PR TITLE
Initial validation

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -98,8 +98,8 @@ class DataSet(torch.utils.data.IterableDataset):
         # Read data with Dask
         self.data = dd.read_parquet(path_to_data / "*.parquet")
 
-        # Get length of df
-        self.length = len(self.data)
+        # Get length of df (critical for the __len__ method)
+        self.length = self.data.index.size.compute()  # ~300x faster than `len(self.data)` for parquet data
 
         self.seq_len = seq_len
         self.pad_token_id = pad_token_id

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -47,6 +47,12 @@ class DataModule(LightningDataModule):
             self.val_dataset = DataSet(self.tokenized_dataset_path / "validation",
                                         self.seq_len,
                                         self.pad_token_id)
+                
+        if stage == "validate" or stage == "validation":
+            # Load dataset
+            self.val_dataset = DataSet(self.tokenized_dataset_path / "validation",
+                                        self.seq_len,
+                                        self.pad_token_id)
             
         if stage == "test":
             # Load dataset

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -206,6 +206,7 @@ def train_model(config: Struct):
                 cloud_region="us-west3")
 
     emissions_tracker.start()
+    trainer.validate(model, datamodule=dm)
     trainer.fit(model, datamodule=dm)
 
     print("\nDone training! Now testing model...")


### PR DESCRIPTION
This addresses concerns raised in #92. All output was tested alongside varios configs by me and @jtappen1 and everything is working as expected, namely that the validation now happens prior to any training as displayed by these tensorboard logs:


![image](https://github.com/user-attachments/assets/2149fe9f-81b8-48ee-90a9-7d9a5f2c4b8b)


Additionally, a small change was made to the dataloader's `__len__()` functionality for efficiency. It was tested and returns the same number as the prior calculation but much faster (on a 10k sample parquet, the prior method took 1.1 seconds, and the new method took .003 seconds).